### PR TITLE
Release 0.2.1: add extended forecast support

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,13 @@ series:
 
 ## Changelog
 
-### 0.2.0 — Bug fixes
+### 0.2.1 — Extended forecast support
+- Added configurable extended forecast sensor with 2-7 day range
+- New `sensor.power_prediction_extended` provides forecasts up to 168 hours (7 days)
+- Configurable max forecast hours via options (48-168 hours, step: 24)
+- Forecast gracefully falls back to historical mean temperature beyond weather data availability
+
+### 0.2.0 — Bug fixes and UI improvements
 - Dynamic peak/off-peak quantile is now always active (toggle removed)
 - Peak and off-peak quantiles remain fully configurable
 - Fixed `NameError` crash when dynamic quantile toggle was disabled

--- a/custom_components/ha_power_predictor/manifest.json
+++ b/custom_components/ha_power_predictor/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ha_power_predictor",
   "name": "HA Power Predictor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "config_flow": true,
   "dependencies": ["recorder"],
   "requirements": [

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "domain": "ha_power_predictor",
   "name": "HA Power Predictor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "config_flow": true,
   "dependencies": ["recorder"],
   "requirements": [


### PR DESCRIPTION
Bump package version to 0.2.1 and add extended forecast support. Update README changelog with details about a new configurable extended forecast sensor (sensor.power_prediction_extended) offering 2–7 day forecasts (up to 168 hours) and configurable max forecast hours (48–168, step 24). Notes that forecasts fall back to historical mean temperature when weather data is unavailable. Files updated: README.md, custom_components/ha_power_predictor/manifest.json, hacs.json.