### PR TITLE
fix(coordinator): skip forecast call when weather entity is not ready

### DIFF
--- a/custom_components/ha_power_predictor/coordinator.py
+++ b/custom_components/ha_power_predictor/coordinator.py
@@ -26,6 +26,7 @@ import pandas as pd
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.statistics import statistics_during_period
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
@@ -300,6 +301,14 @@ class PowerPredictorCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         entity does not provide a forecast — the pipeline will fall back to
         the historical mean temperature for any missing hours.
         """
+        state = self.hass.states.get(entity_id)
+        if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            _LOGGER.debug(
+                "Weather entity '%s' not ready (state=%s); will retry next cycle",
+                entity_id,
+                state.state if state else "missing",
+            )
+            return []
         try:
             response = await self.hass.services.async_call(
                 "weather",


### PR DESCRIPTION
## Summary

Skip the `weather.get_forecasts` service call when the configured weather entity is missing or in `unavailable` / `unknown` state. Returns an empty forecast list so the coordinator falls back to the historical mean temperature for that cycle and tries again on the next refresh.

## Motivation

During Home Assistant startup the coordinator's first refresh can fire before the weather integration finishes loading its entities. The `weather.get_forecasts` call then raises and the user sees a transient WARN log:

> Could not fetch weather forecast from 'weather.xxx': … Predictions will use mean historical temperature for missing hours.

Once the weather entity finishes loading, subsequent cycles succeed normally. The warning is harmless but noisy — once per HA restart, plus one cycle of degraded prediction quality.

## Change

Cheap state check before the service call. If the entity is `None` / `unavailable` / `unknown`, log at DEBUG and return `[]`. The existing try/except around the service call is left in place as a safety net for other failure modes (entity exists but doesn't support hourly forecasts, transient service errors, etc.).

## Testing

Verified locally on HA 2025.x with both Met.no-backed and BoM-backed weather entities — forecasts return normally once entities are loaded, and the transient startup race no longer produces a WARN.
