### PR TITLE
fix(coordinator): handle DST transitions when localizing forecast times

### DIFF
--- a/custom_components/ha_power_predictor/coordinator.py
+++ b/custom_components/ha_power_predictor/coordinator.py
@@ -380,7 +380,17 @@ def _build_future_df(
                 # Naive datetimes are assumed to be in HA's local timezone (not UTC)
                 # This handles integrations like BoM that provide timezone-naive forecasts
                 ha_tz = dt_util.get_default_time_zone()
-                dt = dt.tz_localize(ha_tz)
+                # Resolve DST transitions explicitly so localization never raises:
+                #   ambiguous=False           -> pick standard (non-DST) time on the
+                #                                repeated fall-back hour
+                #   nonexistent="shift_forward" -> shift a spring-forward gap time to the
+                #                                next valid instant
+                # Without these, the repeated/skipped hour raises AmbiguousTimeError /
+                # NonExistentTimeError, which are NOT caught by the except below and would
+                # crash the whole update at the DST changeover.
+                dt = dt.tz_localize(
+                    ha_tz, ambiguous=False, nonexistent="shift_forward"
+                )
             # Convert to the working timezone (derived from historical data)
             dt = dt.tz_convert(tz) if tz else dt
             dt = dt.replace(minute=0, second=0, microsecond=0)


### PR DESCRIPTION
## Summary

Fixes the Home Assistant integration crashing at daylight-saving transitions, and **supersedes #15**.

When the configured weather entity provides **timezone-naive** forecast datetimes (e.g. BoM), `_build_future_df` localizes them with `dt.tz_localize(ha_tz)`. With the default `ambiguous='raise'` / `nonexistent='raise'` behaviour this throws at a DST changeover:

- **Fall-back (DST → Standard):** the repeated wall-clock hour raises `AmbiguousTimeError`.
- **Spring-forward (Standard → DST):** the skipped hour raises `NonExistentTimeError`.

Neither is a subclass of the exceptions in the surrounding `except (KeyError, ValueError, TypeError, AttributeError): continue`, so the exception escapes `_build_future_df` (which runs un-wrapped in the executor) and fails the entire fetch → train → predict cycle for the duration of the transition hour.

## Change

```python
dt = dt.tz_localize(ha_tz, ambiguous=False, nonexistent="shift_forward")
```

- `ambiguous=False` resolves the repeated fall-back hour to standard (non-DST) time.
- `nonexistent="shift_forward"` moves a spring-forward gap time to the next valid instant.

Localization can no longer raise on either transition, so it no longer matters that the surrounding `except` doesn't cover the timezone errors. It's pure pandas — no `pytz` import or dependency — and the affected hour is kept (mapped to a valid instant) rather than dropped.

## Why this supersedes #15

#15 targeted the same fall-back bug but is not safe to merge:

1. It catches `pytz.exceptions.AmbiguousTimeError`, but `pytz` is never imported in `coordinator.py` (nor is it a declared requirement) — so the `except` clause itself raises `NameError` on the exact ambiguous hour it targets, leaving the crash in place.
2. It uses `ambiguous='infer'`, which infers the fold from the order of a `DatetimeIndex`; the loop localizes one **scalar** `Timestamp` per iteration, so `'infer'` can never resolve an ambiguous scalar and always raises.
3. It only addressed the fall-back transition, not the spring-forward `NonExistentTimeError` gap.

## Testing

- `python -m py_compile` passes on the changed module.
- `ambiguous=False` and `nonexistent="shift_forward"` are documented non-raising options of `tz_localize`, valid for scalar `Timestamp`s and independent of whether the tz is a `pytz` or stdlib `zoneinfo` object (HA's `dt_util.get_default_time_zone()` returns the latter).
- Full runtime verification requires a live Home Assistant instance with recorder statistics; this change is confined to the timezone-localization call in the forecast-lookup loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
