### PR TITLE
ci: add ruff linting (lenient)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+# Style/quality feedback via ruff (Home Assistant's standard linter).
+# Advisory for now: it reports problems but isn't a merge gate. The rule set
+# in pyproject.toml is intentionally lenient and can be tightened over time.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        # Pinned to match the version used locally so CI and local agree.
+        run: pip install ruff==0.15.17
+      - name: Ruff check
+        run: ruff check .

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.bak
 /.idea
-/__pycache__
+__pycache__/
+*.pyc
 48hr.txt

--- a/custom_components/ha_power_predictor/coordinator.py
+++ b/custom_components/ha_power_predictor/coordinator.py
@@ -22,7 +22,6 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.statistics import statistics_during_period
 from homeassistant.config_entries import ConfigEntry
@@ -60,7 +59,6 @@ from .const import (
     DOMAIN,
     MIN_TRAINING_SAMPLES,
 )
-
 from .data_processing import add_lagged_features, get_default_features, process_ha_statistics
 from .models import QuantileRegressionModel, predict_iterative
 
@@ -79,7 +77,9 @@ class PowerPredictorCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self.entry = entry
         cfg = {**entry.data, **entry.options}
-        interval_minutes = int(cfg.get(CONF_UPDATE_INTERVAL_MINUTES, DEFAULT_UPDATE_INTERVAL_MINUTES))
+        interval_minutes = int(
+            cfg.get(CONF_UPDATE_INTERVAL_MINUTES, DEFAULT_UPDATE_INTERVAL_MINUTES)
+        )
 
         super().__init__(
             hass,
@@ -116,7 +116,12 @@ class PowerPredictorCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         }
 
         # ── Step 1: Fetch recorder statistics ────────────────────────────────
-        _LOGGER.debug("Fetching %d days of statistics for %s and %s", history_days, power_entity, temp_entity)
+        _LOGGER.debug(
+            "Fetching %d days of statistics for %s and %s",
+            history_days,
+            power_entity,
+            temp_entity,
+        )
         now_utc = dt_util.utcnow()
         start_utc = now_utc - timedelta(days=history_days)
 

--- a/custom_components/ha_power_predictor/models.py
+++ b/custom_components/ha_power_predictor/models.py
@@ -22,9 +22,10 @@ Algorithm overview (IRLS for quantile regression):
     typically 20–50 iterations for datasets of this size.
 """
 
-import numpy as np
 import logging
-from typing import Dict, Optional, Any
+from typing import Any, Dict, Optional
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+# Ruff configuration for HA Power Predictor.
+#
+# Lenient starter rule set so CI is green today: real errors (pyflakes F),
+# pycodestyle errors/warnings (E/W) and import sorting (I). Tighten over time by
+# adding rule groups (e.g. "UP", "B", "D" for docstrings, "T20" to ban print).
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]


### PR DESCRIPTION
## Summary

Phase 2 of the CI/CD rollout: adds **ruff linting** (Home Assistant's standard linter) in a deliberately lenient configuration so the check is green today and can be tightened over time.

## What's included

- **`pyproject.toml`** — ruff config: `line-length = 100`, `target-version = "py312"`, `select = ["E", "F", "W", "I"]` (pycodestyle errors/warnings, pyflakes, import sorting). Stricter groups (docstrings, `print` bans, pyupgrade) are intentionally left out for now.
- **`.github/workflows/lint.yml`** — runs `ruff check .` on push/PR, pinned to ruff 0.15.17 to match local. **Advisory** — it reports issues but isn't a merge gate.
- Fixes for the four issues the lenient set flagged (so the check passes):
  - sorted the import blocks in `coordinator.py` and `models.py` (`ruff --fix`)
  - wrapped two >100-char lines in `coordinator.py`
- **`.gitignore`** — ignore nested `__pycache__/` and `*.pyc` (only the repo-root `__pycache__` was ignored before, so build artifacts could be staged).

## Verification

- `ruff check .` passes locally with this config (`All checks passed!`)
- `coordinator.py` still compiles; `lint.yml` validated as YAML
- the Ruff check plus the existing hassfest/HACS validation should be green on this PR

## Tightening later

Add rule groups to `select` as the code is cleaned up — e.g. `"UP"` (pyupgrade), `"B"` (bugbear), `"D"` (docstrings), `"T20"` (would flag the intentional `print()` calls in `models.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
