### PR TITLE
test: add pytest suite for pure modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  pure:
+    # Fast job: the model + data-processing modules depend only on numpy/pandas,
+    # so they are tested with no Home Assistant install. (See tests/pure/conftest.py
+    # for how they're imported without loading the HA-dependent package __init__.)
+    name: Pure module tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install pytest "numpy>=1.24.0" "pandas>=2.0.0"
+      - name: Run pure tests
+        run: pytest tests/pure -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/pure/conftest.py
+++ b/tests/pure/conftest.py
@@ -1,0 +1,15 @@
+"""Make the integration's pure modules importable without loading Home Assistant.
+
+``models.py`` and ``data_processing.py`` depend only on numpy/pandas, but importing
+them through the normal package path (``custom_components.ha_power_predictor.models``)
+would execute the package ``__init__.py``, which imports Home Assistant. Adding the
+package directory itself to ``sys.path`` lets these tests import them as standalone
+top-level modules, so the pure test job needs no Home Assistant install.
+"""
+
+import pathlib
+import sys
+
+_PKG = pathlib.Path(__file__).resolve().parents[2] / "custom_components" / "ha_power_predictor"
+if str(_PKG) not in sys.path:
+    sys.path.insert(0, str(_PKG))

--- a/tests/pure/test_data_processing.py
+++ b/tests/pure/test_data_processing.py
@@ -1,0 +1,87 @@
+"""Unit tests for the recorder-statistics processing helpers (data_processing.py)."""
+
+import datetime
+
+import data_processing as dp
+import pandas as pd
+import pytest
+
+
+def _stat(start, mean):
+    return {"start": start, "mean": mean}
+
+
+def test_parse_start_epoch_float():
+    assert dp._parse_start(0.0) == pd.Timestamp("1970-01-01 00:00:00", tz="UTC")
+
+
+def test_parse_start_naive_datetime_localized_utc():
+    ts = dp._parse_start(datetime.datetime(2026, 1, 1, 12, 0, 0))
+    assert ts == pd.Timestamp("2026-01-01 12:00:00", tz="UTC")
+
+
+def test_parse_start_aware_unchanged():
+    aware = pd.Timestamp("2026-01-01 12:00:00", tz="UTC")
+    assert dp._parse_start(aware) == aware
+
+
+def test_process_inner_join_and_temporal_features():
+    base = 1_700_000_000
+    power = [_stat(base + 3600 * i, 1.0 + i) for i in range(3)]
+    temp = [_stat(base + 3600 * i, 20.0 + i) for i in range(3)]
+    df = dp.process_ha_statistics(power, temp)
+    assert list(df.columns) == [
+        "timestamp", "consumption", "temperature", "year", "month", "day_of_week", "hour",
+    ]
+    assert df["consumption"].tolist() == [1.0, 2.0, 3.0]
+    assert df["temperature"].tolist() == [20.0, 21.0, 22.0]
+    assert df["hour"].iloc[0] == df["timestamp"].iloc[0].hour
+
+
+def test_process_drops_none_means():
+    base = 1_700_000_000
+    power = [_stat(base, 1.0), _stat(base + 3600, None), _stat(base + 7200, 3.0)]
+    temp = [_stat(base + 3600 * i, 20.0 + i) for i in range(3)]
+    assert dp.process_ha_statistics(power, temp)["consumption"].tolist() == [1.0, 3.0]
+
+
+def test_process_inner_join_only_overlap():
+    base = 1_700_000_000
+    power = [_stat(base + 3600 * i, float(i)) for i in range(0, 3)]
+    temp = [_stat(base + 3600 * i, float(i)) for i in range(1, 4)]
+    assert len(dp.process_ha_statistics(power, temp)) == 2
+
+
+def test_process_no_overlap_raises():
+    power = [_stat(1_700_000_000, 1.0)]
+    temp = [_stat(1_700_100_000, 20.0)]
+    with pytest.raises(ValueError):
+        dp.process_ha_statistics(power, temp)
+
+
+def test_process_empty_power_raises():
+    with pytest.raises(ValueError):
+        dp.process_ha_statistics([], [_stat(1_700_000_000, 20.0)])
+
+
+def test_add_lagged_features_zero_returns_unchanged():
+    df = pd.DataFrame({"consumption": [1.0, 2.0], "temperature": [10.0, 11.0]})
+    assert dp.add_lagged_features(df, 0, 0).equals(df)
+
+
+def test_add_lagged_features_shifts_and_drops_leading_rows():
+    df = pd.DataFrame({
+        "consumption": [1.0, 2.0, 3.0, 4.0],
+        "temperature": [10.0, 11.0, 12.0, 13.0],
+    })
+    out = dp.add_lagged_features(df, n_power_lags=2, n_temp_lags=1)
+    assert len(out) == 2
+    assert {"power_lag_1", "power_lag_2", "temp_lag_1"} <= set(out.columns)
+    assert out["consumption"].iloc[0] == 3.0
+    assert out["power_lag_1"].iloc[0] == 2.0
+    assert out["power_lag_2"].iloc[0] == 1.0
+    assert out["temp_lag_1"].iloc[0] == 11.0
+
+
+def test_get_default_features_exact_order():
+    assert dp.get_default_features() == ["year", "month", "day_of_week", "hour", "temperature"]

--- a/tests/pure/test_models.py
+++ b/tests/pure/test_models.py
@@ -1,0 +1,108 @@
+"""Unit tests for the pure-numpy quantile regression model (models.py)."""
+
+import models
+import numpy as np
+import pytest
+
+
+def test_r2_perfect_and_zero_variance():
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    assert models._r2_score(y, y) == 1.0
+    # Zero variance in y_true -> ss_tot == 0 -> guarded return of 0.0.
+    const = np.array([5.0, 5.0, 5.0])
+    assert models._r2_score(const, np.array([1.0, 2.0, 3.0])) == 0.0
+
+
+def test_mae_and_rmse_known_values():
+    assert models._mae(np.array([0.0, 0.0, 0.0]), np.array([1.0, 1.0, 1.0])) == 1.0
+    assert models._rmse(np.array([0.0, 0.0]), np.array([2.0, 2.0])) == 2.0
+
+
+def test_irls_recovers_linear_relationship():
+    x = np.linspace(0, 10, 200).reshape(-1, 1)
+    y = 3.0 * x[:, 0] + 2.0
+    coeffs = models._fit_quantile_irls(x, y, quantile=0.5)
+    assert coeffs.shape == (2,)
+    assert abs(coeffs[0] - 2.0) < 0.3
+    assert abs(coeffs[1] - 3.0) < 0.3
+    assert np.allclose(models._predict_quantile_irls(x, coeffs), y, atol=0.2)
+
+
+def test_higher_quantile_predicts_higher_on_average():
+    rng = np.random.default_rng(42)
+    x = rng.uniform(0, 10, size=(500, 1))
+    y = 2.0 * x[:, 0] + rng.normal(0, 1.0, size=500)
+    p50 = models._predict_quantile_irls(x, models._fit_quantile_irls(x, y, 0.5))
+    p90 = models._predict_quantile_irls(x, models._fit_quantile_irls(x, y, 0.9))
+    assert p90.mean() > p50.mean()
+
+
+def test_predict_before_train_raises():
+    model = models.QuantileRegressionModel()
+    with pytest.raises(RuntimeError):
+        model.predict(np.zeros((3, 2)))
+
+
+def test_train_predict_shape_and_coverage():
+    rng = np.random.default_rng(1)
+    x = rng.uniform(0, 10, size=(300, 2))
+    y = x[:, 0] + 0.5 * x[:, 1] + rng.normal(0, 0.5, size=300)
+    model = models.QuantileRegressionModel(quantile=0.75)
+    model.train(x, y)
+    preds = model.predict(x)
+    assert preds.shape == (300,)
+    assert 60.0 <= model.calculate_coverage(y, preds) <= 90.0
+    assert set(model.evaluate(y, preds)) == {"r2", "mae", "rmse"}
+
+
+def test_dynamic_peak_offpeak_routing():
+    rng = np.random.default_rng(7)
+    hours = np.tile(np.arange(24), 20)
+    x = rng.uniform(0, 5, size=(len(hours), 2))
+    peak = (hours >= 9) & (hours <= 22)
+    y = x[:, 0] + np.where(peak, 5.0, 0.0) + rng.normal(0, 0.3, size=len(hours))
+    config = {"peak_start": 9, "peak_end": 22, "peak_quantile": 0.75, "offpeak_quantile": 0.5}
+    model = models.QuantileRegressionModel(dynamic_config=config)
+    model.train(x, y, hours)
+    assert model._coeffs_peak is not None
+    assert model._coeffs_offpeak is not None
+    preds = model.predict(x, hours)
+    assert preds[peak].mean() > preds[~peak].mean() + 2.0
+
+
+def test_dynamic_all_peak_leaves_offpeak_unset():
+    rng = np.random.default_rng(3)
+    hours = np.full(50, 12)
+    x = rng.uniform(0, 5, size=(50, 1))
+    y = x[:, 0] + rng.normal(0, 0.2, size=50)
+    config = {"peak_start": 9, "peak_end": 22, "peak_quantile": 0.75, "offpeak_quantile": 0.5}
+    model = models.QuantileRegressionModel(dynamic_config=config)
+    model.train(x, y, hours)
+    assert model._coeffs_peak is not None
+    assert model._coeffs_offpeak is None
+    assert model.predict(x, hours).shape == (50,)
+
+
+def test_predict_iterative_no_power_lags_short_circuits():
+    rng = np.random.default_rng(5)
+    x = rng.uniform(0, 5, size=(20, 2))
+    y = x[:, 0] + rng.normal(0, 0.3, size=20)
+    model = models.QuantileRegressionModel(quantile=0.6)
+    model.train(x, y)
+    result = models.predict_iterative(x, np.zeros(20), model, ["hour", "temperature"], 0)
+    assert result["iterative"] is False
+    assert np.allclose(result["predictions"], model.predict(x))
+
+
+def test_predict_iterative_feeds_predictions_into_power_lag():
+    class Echo:
+        """Stand-in model that echoes the power_lag_1 feature back as the prediction."""
+
+        def predict(self, x, hours=None):
+            return np.array([x[0, 0]])
+
+    x = np.array([[7.0], [0.0], [0.0], [0.0]])
+    result = models.predict_iterative(x, np.zeros(4), Echo(), ["power_lag_1"], 1)
+    assert result["iterative"] is True
+    # Each step writes the previous prediction into power_lag_1, so all equal the seed.
+    assert np.allclose(result["predictions"], [7.0, 7.0, 7.0, 7.0])


### PR DESCRIPTION
## Summary

Phase 3a of the CI/CD rollout: the first **automated tests** plus a `Tests` workflow.

This repo had zero tests. The integration splits into **pure modules** (numpy/pandas only) and **HA-coupled modules** (need the Home Assistant test harness). This PR covers the pure core — the highest-value, highest-confidence logic — which runs with no HA install.

## What's included

- **`tests/pure/test_models.py`** — the IRLS quantile-regression model: metric helpers (incl. the zero-variance R² guard), `_fit_quantile_irls` recovering a known line, higher-quantile-predicts-higher, the `RuntimeError` before training, dynamic peak/off-peak routing (+ the all-peak edge case), and `predict_iterative` (no-lag short-circuit + auto-regressive feedback).
- **`tests/pure/test_data_processing.py`** — `_parse_start` (epoch float + datetime), `process_ha_statistics` (inner join, None-mean drop, temporal features, no-overlap/empty error paths), `add_lagged_features` (shift + leading-NaN drop), `get_default_features`.
- **`tests/pure/conftest.py`** — adds the package dir to `sys.path` so `models`/`data_processing` import as standalone modules *without* executing the package `__init__.py` (which imports Home Assistant). That's what lets the pure job skip installing HA.
- **`pyproject.toml`** — pytest `testpaths`.
- **`.github/workflows/test.yml`** — runs `pytest tests/pure` on Python 3.12.

## Verification

- `ruff check .` clean; YAML + syntax validated locally.
- pytest can't run in the local Windows env (no pandas wheel for the local Python), so the suite is validated by CI — see the **Tests** check on this PR.

## Next (Phase 3b)

HA-harness tests for `config_flow` and `_build_future_df` using `pytest-homeassistant-custom-component==0.13.339` (which pins `homeassistant==2026.6.3`, Python 3.14), added as a second `harness` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
