### PR TITLE
ci: add release automation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+# CD: when you PUBLISH a GitHub release, stamp the tag's version into the
+# integration manifest and attach a ready-to-install zip as a release asset.
+# (Triggers only on a published release, so it never runs on push/PR.)
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  release:
+    name: Build release asset
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write          # required only to upload the asset to the release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stamp version from the release tag
+        shell: bash
+        run: |
+          version="${{ github.event.release.tag_name }}"
+          version="${version#v}"          # strip a leading "v" (v0.2.2 -> 0.2.2)
+          tmp="$(mktemp)"
+          jq --arg v "$version" '.version = $v' \
+            custom_components/ha_power_predictor/manifest.json > "$tmp"
+          mv "$tmp" custom_components/ha_power_predictor/manifest.json
+
+      - name: Zip the integration
+        run: |
+          cd custom_components/ha_power_predictor
+          zip -r ha_power_predictor.zip .
+
+      - name: Attach zip to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: custom_components/ha_power_predictor/ha_power_predictor.zip


### PR DESCRIPTION
## Summary

Phase 4 of the CI/CD rollout: **release automation**.

`.github/workflows/release.yml` runs when you **publish a GitHub Release**. It:
1. reads the release tag (e.g. `v0.2.2`), strips a leading `v`, and stamps that version into `manifest.json` (inside the build — no commit back to the repo);
2. zips the integration folder;
3. attaches `ha_power_predictor.zip` to the release via `softprops/action-gh-release@v2`.

It triggers only on `release: published`, so it doesn't run on this PR — the validate/lint/test checks here are the existing ones.

## Why `zip_release` isn't enabled yet

The plan's final touch is setting `"zip_release": true` + `"filename"` in `hacs.json` so HACS installs from that single zip asset. I've **deliberately deferred** that one-line change: turning it on before any release carries the zip risks HACS looking for a `ha_power_predictor.zip` that doesn't exist on the current latest release (`v0.2.1`).

**Safe activation sequence (after merging this):**
1. Cut a release — bump `version` in `manifest.json`, update the README changelog, tag `vX.Y.Z`, **Publish**.
2. Confirm the Release run attached `ha_power_predictor.zip`.
3. Then enable `zip_release` + `filename` in `hacs.json` (a one-line follow-up PR).

## Release runbook (going forward)

1. Bump `version` in `manifest.json`.
2. Add a `### X.Y.Z — title` entry to the README changelog.
3. PR → confirm CI green → merge to `main`.
4. Create a GitHub Release with tag `vX.Y.Z` (standardize on the `v` prefix — your tag history is mixed) and Publish.
5. `release.yml` stamps the manifest + attaches the zip automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
