### PR TITLE
docs: document CI/CD + prep v0.2.2 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ hacs.json              # HACS metadata
 repository.yaml        # HACS repository descriptor
 README.md              # user-facing docs (install, config, dashboard example)
 images/                # README screenshots and banners
+pyproject.toml         # ruff (lint) + pytest config
+tests/pure/            # pytest suite for the HA-independent modules
+.github/workflows/     # CI/CD: validate.yml, lint.yml, test.yml, release.yml
 ```
 
 See `custom_components/ha_power_predictor/CLAUDE.md` for module-level internals
@@ -99,23 +102,24 @@ just calls `coordinator.async_request_refresh()` on press.
 
 ## Validating changes
 
-This repo has **no test suite, no linter config, and no CI** committed. Validate
-changes the way an HA custom component is normally validated:
+CI runs automatically on every push/PR to `main` (see `.github/workflows/`):
+**hassfest** + **HACS** validation (`validate.yml`), **ruff** lint (`lint.yml`),
+and the **pytest** suite (`test.yml`). Reproduce them locally:
 
-- **Syntax check** every changed module:
-  `python -m py_compile custom_components/ha_power_predictor/*.py`
+- **Lint:** `ruff check .` (config in `pyproject.toml`; lenient set `E/F/W/I`).
+- **Tests:** `pytest tests/pure` (needs only `pytest`, `numpy`, `pandas` — the
+  pure modules import no Home Assistant). HA-harness tests are not set up yet.
 - **JSON validity** for `manifest.json`, `hacs.json`, `strings.json`,
   `translations/en.json` (e.g. `python -m json.tool <file>`).
 - **Manual run:** copy `custom_components/ha_power_predictor/` into a Home
   Assistant `config/custom_components/` directory, restart HA, add the
   integration via the UI, and watch the logs (the coordinator logs each pipeline
   stage at `debug`/`info`).
-- Home Assistant's own `hassfest` and HACS validation are the canonical checks
-  for integrations like this, even though no GitHub Action is configured here.
 
-There is no automated way to verify the model output without a live HA instance
-that has recorder statistics — reason about model changes from the code and the
-docstrings in `models.py`.
+`hassfest` and the HACS action are the canonical structural checks and now run
+in CI. There is still no automated way to verify model *output* without a live
+HA instance with recorder statistics — reason about model changes from the code
+and the docstrings in `models.py`.
 
 ## Releasing / bumping the version
 
@@ -124,8 +128,14 @@ read it). `hacs.json` must NOT carry a `version` key — the HACS validation
 action rejects it. When releasing:
 
 1. Bump `version` in `manifest.json`.
-2. Add a section to the Changelog in `README.md`.
-3. Tag/release on GitHub (HACS serves the latest GitHub release).
+2. Add a `### X.Y.Z — title` entry to the Changelog in `README.md`.
+3. PR → confirm CI is green → merge to `main`.
+4. Publish a GitHub release with tag `vX.Y.Z` (use the `v` prefix consistently).
+   `release.yml` then stamps the tag's version into the manifest and attaches
+   `ha_power_predictor.zip` to the release. HACS serves the latest release.
+
+> `zip_release`/`filename` in `hacs.json` make HACS install from that zip asset;
+> only enable them once a release actually carries the zip.
 
 ## Things that must stay consistent
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ series:
 
 ## Changelog
 
+### 0.2.2 — Daylight-saving fix
+- Fixed a crash at daylight-saving transitions when localizing timezone-naive weather forecast timestamps (e.g. BoM): both the fall-back (repeated hour) and spring-forward (skipped hour) are now handled.
+- Developer tooling: added CI (hassfest, HACS, ruff, pytest) and release automation via GitHub Actions.
+
 ### 0.2.1 — Extended forecast support
 - Added configurable extended forecast sensor with 2-7 day range
 - New `sensor.power_prediction_extended` provides forecasts up to 168 hours (7 days)

--- a/custom_components/ha_power_predictor/manifest.json
+++ b/custom_components/ha_power_predictor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/isaacjmannion/ha-power-predictor/issues",
   "requirements": ["numpy>=1.24.0", "pandas>=2.0.0"],
-  "version": "0.2.1"
+  "version": "0.2.2"
 }


### PR DESCRIPTION
## Summary

Wraps up the CI/CD work and prepares the first automated release.

- **`CLAUDE.md`** — now documents the real pipeline (it previously said "no test suite, no linter config, and no CI"): the `validate`/`lint`/`test` workflows, local `ruff check .` / `pytest tests/pure` commands, the release runbook, and the new files in the repo layout.
- **`manifest.json`** — version `0.2.1` → `0.2.2`.
- **`README.md`** — changelog entry for `0.2.2` (the daylight-saving fix from #20 plus the CI/CD tooling).

## How this fits the zip-release activation

Merging this readies a `v0.2.2` release. The safe sequence:
1. Merge this PR.
2. Publish a GitHub release tagged **`v0.2.2`** → `release.yml` attaches `ha_power_predictor.zip`.
3. Merge the follow-up PR that enables `zip_release` in `hacs.json` (opened separately — do **not** merge it before step 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
