### PR TITLE
ci: enable HACS zip_release (merge AFTER publishing v0.2.2)

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
   "name": "HA Power Predictor",
-  "homeassistant": "2024.1.0"
+  "homeassistant": "2024.1.0",
+  "zip_release": true,
+  "filename": "ha_power_predictor.zip"
 }


### PR DESCRIPTION
## ⚠️ Do not merge until `v0.2.2` is published

This is the final activation step for release automation. It adds to `hacs.json`:

```json
"zip_release": true,
"filename": "ha_power_predictor.zip"
```

With these set, HACS installs the single `ha_power_predictor.zip` asset from the latest GitHub release (faster, atomic) instead of downloading the repository tree.

**Why ordering matters:** the current latest release (`v0.2.1`) has no such asset. Enabling this before a release carries the zip risks HACS looking for a file that isn't there. It must only go live once a release ships the zip.

## Finish sequence

1. ✅ Done — `release.yml` is on `main`, and `main` is at version `0.2.2`.
2. **Publish a GitHub release tagged `v0.2.2`** → `release.yml` builds and attaches `ha_power_predictor.zip`.
3. Confirm the asset is on the release, then **merge this PR**. (Re-run the checks here first if they were red before the release existed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
