### PR TITLE
feat: per-hour fixed offset for power predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,24 @@ Tune the model behaviour via **Settings → Devices & Services → HA Power Pred
 | `Peak Quantile` | Quantile applied during peak hours | 0.75 |
 | `Off-Peak Quantile` | Quantile applied during off-peak hours | 0.50 |
 | `Max Forecast Hours` | Maximum hours to forecast (48–168 hours / 2-7 days) | 48 |
+| `Hour Offsets` | Fixed kW added to the forecast for specific hours of the day (see [Hourly Offsets](#hourly-offsets)) | _(none)_ |
 
 > **Note**: Forecasts beyond weather forecast availability (typically 2-3 days) will use historical average temperature and may have reduced accuracy.
+
+### Hourly Offsets
+
+If a known recurring load isn't captured well by the model — an EV charging overnight, a pool pump on a timer — add a **fixed kW offset for specific hours of the day**. Under **Configure**, add a row per hour with the kW to add (offsets may be negative). Hours you don't list are left unchanged, and the result is still bounded by the Min/Max Predicted Power clamp.
+
+Example — add 7 kW while an EV charges from 1 am to 4 am:
+
+| Hour | Offset (kW) |
+|------|-------------|
+| 1 | 7 |
+| 2 | 7 |
+| 3 | 7 |
+| 4 | 7 |
+
+> Hours use the same (UTC-based) convention as the peak period.
 
 ---
 
@@ -202,7 +218,7 @@ series:
 
 ## Requirements
 
-- Home Assistant **2024.1** or newer
+- Home Assistant **2025.7** or newer (the hourly-offset editor uses the object-selector row form introduced in 2025.7)
 - The power and temperature entities must have **long-term statistics** enabled (recorder integration, statistics enabled for the entity)
 - A weather entity providing an **hourly forecast**
 

--- a/README.md
+++ b/README.md
@@ -79,24 +79,24 @@ Tune the model behaviour via **Settings → Devices & Services → HA Power Pred
 | `Peak Quantile` | Quantile applied during peak hours | 0.75 |
 | `Off-Peak Quantile` | Quantile applied during off-peak hours | 0.50 |
 | `Max Forecast Hours` | Maximum hours to forecast (48–168 hours / 2-7 days) | 48 |
-| `Hour Offsets` | Fixed kW added to the forecast for specific hours of the day (see [Hourly Offsets](#hourly-offsets)) | _(none)_ |
+| `Hour-of-day Offsets` | Fixed kW added at chosen hours of the day, local time (see [Hour-of-day Offsets](#hour-of-day-offsets)) | _(none)_ |
 
 > **Note**: Forecasts beyond weather forecast availability (typically 2-3 days) will use historical average temperature and may have reduced accuracy.
 
-### Hourly Offsets
+### Hour-of-day Offsets
 
-If a known recurring load isn't captured well by the model — an EV charging overnight, a pool pump on a timer — add a **fixed kW offset for specific hours of the day**. Under **Configure**, add a row per hour with the kW to add (offsets may be negative). Hours you don't list are left unchanged, and the result is still bounded by the Min/Max Predicted Power clamp.
+If a known recurring load isn't captured well by the model — an EV charging overnight, a pool pump on a timer — add a **fixed kW offset at a specific hour of the day** (local clock time). Under **Configure**, add a row giving the hour (0–23) and the kW to add; the offset is applied at that hour **every day**. Offsets may be negative, hours you don't list are left unchanged, and the result is still bounded by the Min/Max Predicted Power clamp.
 
 Example — add 7 kW while an EV charges from 1 am to 4 am:
 
-| Hour | Offset (kW) |
-|------|-------------|
+| Hour of day | Offset (kW) |
+|-------------|-------------|
 | 1 | 7 |
 | 2 | 7 |
 | 3 | 7 |
 | 4 | 7 |
 
-> Hours use the same (UTC-based) convention as the peak period.
+> Hours are **local clock time** — e.g. hour 13 applies at 1 pm every day.
 
 ---
 

--- a/custom_components/ha_power_predictor/config_flow.py
+++ b/custom_components/ha_power_predictor/config_flow.py
@@ -155,6 +155,7 @@ def _model_schema(defaults: dict) -> vol.Schema:
                     "hour": {
                         "selector": {"number": {"min": 0, "max": 23, "step": 1, "mode": "box"}},
                         "required": True,
+                        "label": "Hour of day (0-23, local time)",
                     },
                     "offset": {
                         "selector": {
@@ -167,6 +168,7 @@ def _model_schema(defaults: dict) -> vol.Schema:
                             }
                         },
                         "required": True,
+                        "label": "Offset (kW)",
                     },
                 },
             )

--- a/custom_components/ha_power_predictor/config_flow.py
+++ b/custom_components/ha_power_predictor/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import selector
 
 from .const import (
     CONF_HISTORY_DAYS,
+    CONF_HOUR_OFFSETS,
     CONF_INTEGRATION_NAME,
     CONF_MAX_FORECAST_HOURS,
     CONF_MAX_POWER,
@@ -143,6 +144,33 @@ def _model_schema(defaults: dict) -> vol.Schema:
         ): selector.NumberSelector(
             selector.NumberSelectorConfig(min=48, max=MAX_FORECAST_HOURS_LIMIT, step=24, mode="box")
         ),
+        vol.Optional(
+            CONF_HOUR_OFFSETS,
+            default=_d(CONF_HOUR_OFFSETS, []),
+        ): selector.ObjectSelector(
+            selector.ObjectSelectorConfig(
+                multiple=True,
+                label_field="hour",
+                fields={
+                    "hour": {
+                        "selector": {"number": {"min": 0, "max": 23, "step": 1, "mode": "box"}},
+                        "required": True,
+                    },
+                    "offset": {
+                        "selector": {
+                            "number": {
+                                "min": -50,
+                                "max": 50,
+                                "step": 0.1,
+                                "mode": "box",
+                                "unit_of_measurement": "kW",
+                            }
+                        },
+                        "required": True,
+                    },
+                },
+            )
+        ),
     })
 
 
@@ -181,13 +209,17 @@ class PowerPredictorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict = {}
 
         if user_input is not None:
-            data = {**self._entity_data, **_coerce_numbers(user_input)}
-            title = self._entity_data.get(CONF_INTEGRATION_NAME, DEFAULT_INTEGRATION_NAME)
-            return self.async_create_entry(title=title, data=data)
+            error = _hour_offsets_error(user_input)
+            if error:
+                errors["base"] = error
+            else:
+                data = {**self._entity_data, **_coerce_numbers(user_input)}
+                title = self._entity_data.get(CONF_INTEGRATION_NAME, DEFAULT_INTEGRATION_NAME)
+                return self.async_create_entry(title=title, data=data)
 
         return self.async_show_form(
             step_id="model",
-            data_schema=_model_schema({}),
+            data_schema=_model_schema(user_input or {}),
             errors=errors,
         )
 
@@ -220,15 +252,20 @@ class PowerPredictorOptionsFlow(config_entries.OptionsFlow):
         user_input: dict | None = None,
     ) -> config_entries.FlowResult:
         """Single options step — all model parameters on one screen."""
+        errors: dict = {}
         if user_input is not None:
-            return self.async_create_entry(title="", data=_coerce_numbers(user_input))
+            error = _hour_offsets_error(user_input)
+            if not error:
+                return self.async_create_entry(title="", data=_coerce_numbers(user_input))
+            errors["base"] = error
 
-        # Pre-populate with existing values (options override data)
-        current = {**self._config_entry.data, **self._config_entry.options}
+        # Pre-populate with existing values (options override data, then this submission)
+        current = {**self._config_entry.data, **self._config_entry.options, **(user_input or {})}
 
         return self.async_show_form(
             step_id="init",
             data_schema=_model_schema(current),
+            errors=errors,
         )
 
 
@@ -248,3 +285,23 @@ def _coerce_numbers(data: dict) -> dict:
         CONF_MAX_FORECAST_HOURS,
     }
     return {k: int(v) if k in int_fields else v for k, v in data.items()}
+
+
+def _hour_offsets_error(user_input: dict) -> str | None:
+    """Validate the hour-offset rows; return an error key if invalid, else None."""
+    raw = user_input.get(CONF_HOUR_OFFSETS)
+    if not raw:
+        return None
+    if not isinstance(raw, list):
+        return "invalid_hour_offsets"
+    for entry in raw:
+        if not isinstance(entry, dict):
+            return "invalid_hour_offsets"
+        try:
+            hour = int(entry.get("hour"))
+            float(entry.get("offset"))
+        except (TypeError, ValueError):
+            return "invalid_hour_offsets"
+        if not 0 <= hour <= 23:
+            return "invalid_hour_offsets"
+    return None

--- a/custom_components/ha_power_predictor/const.py
+++ b/custom_components/ha_power_predictor/const.py
@@ -20,6 +20,7 @@ CONF_UPDATE_INTERVAL_MINUTES = "update_interval_minutes"
 CONF_MIN_POWER = "min_power"
 CONF_MAX_POWER = "max_power"
 CONF_MAX_FORECAST_HOURS = "max_forecast_hours"
+CONF_HOUR_OFFSETS = "hour_offsets"
 
 # Defaults
 DEFAULT_INTEGRATION_NAME = "Power Predictor"
@@ -34,6 +35,7 @@ DEFAULT_UPDATE_INTERVAL_MINUTES = 10
 DEFAULT_MIN_POWER = 0.5
 DEFAULT_MAX_POWER = 15.0
 DEFAULT_MAX_FORECAST_HOURS = 48  # 2 days
+DEFAULT_HOUR_OFFSETS: list = []  # rows of {"hour": int, "offset": float kW}
 
 # Pipeline constants
 MIN_TRAINING_SAMPLES = 24  # 1 day of hourly statistics

--- a/custom_components/ha_power_predictor/coordinator.py
+++ b/custom_components/ha_power_predictor/coordinator.py
@@ -253,9 +253,12 @@ class PowerPredictorCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         predictions: list[dict[str, Any]] = []
         for i, (_, row) in enumerate(df_future.iterrows()):
-            # Add the configured per-hour offset before clamping so min/max_power
-            # still bound the published value.
-            offset = hour_offsets.get(int(row["hour"]), 0.0)
+            # Add the configured offset before clamping so min/max_power still
+            # bound the published value. Match on the LOCAL hour-of-day so an
+            # offset for e.g. hour 13 lands at 1 pm on the user's clock — the same
+            # local time the forecast is displayed in (sensor.py shows local time).
+            local_hour = dt_util.as_local(row["timestamp"]).hour
+            offset = hour_offsets.get(local_hour, 0.0)
             value = min(max_power, max(min_power, raw_preds[i] + offset))
             predictions.append(
                 {

--- a/custom_components/ha_power_predictor/coordinator.py
+++ b/custom_components/ha_power_predictor/coordinator.py
@@ -32,6 +32,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_HISTORY_DAYS,
+    CONF_HOUR_OFFSETS,
     CONF_MAX_FORECAST_HOURS,
     CONF_MAX_POWER,
     CONF_MIN_POWER,
@@ -46,6 +47,7 @@ from .const import (
     CONF_UPDATE_INTERVAL_MINUTES,
     CONF_WEATHER_FORECAST_ENTITY,
     DEFAULT_HISTORY_DAYS,
+    DEFAULT_HOUR_OFFSETS,
     DEFAULT_MAX_FORECAST_HOURS,
     DEFAULT_MAX_POWER,
     DEFAULT_MIN_POWER,
@@ -59,7 +61,12 @@ from .const import (
     DOMAIN,
     MIN_TRAINING_SAMPLES,
 )
-from .data_processing import add_lagged_features, get_default_features, process_ha_statistics
+from .data_processing import (
+    add_lagged_features,
+    get_default_features,
+    normalize_hour_offsets,
+    process_ha_statistics,
+)
 from .models import QuantileRegressionModel, predict_iterative
 
 _LOGGER = logging.getLogger(__name__)
@@ -105,6 +112,7 @@ class PowerPredictorCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         n_power_lags: int = int(cfg.get(CONF_N_POWER_LAGS, DEFAULT_N_POWER_LAGS))
         n_temp_lags: int = int(cfg.get(CONF_N_TEMP_LAGS, DEFAULT_N_TEMP_LAGS))
         max_forecast_hours: int = int(cfg.get(CONF_MAX_FORECAST_HOURS, DEFAULT_MAX_FORECAST_HOURS))
+        hour_offsets = normalize_hour_offsets(cfg.get(CONF_HOUR_OFFSETS, DEFAULT_HOUR_OFFSETS))
 
         min_power: float = float(cfg.get(CONF_MIN_POWER, DEFAULT_MIN_POWER))
         max_power: float = float(cfg.get(CONF_MAX_POWER, DEFAULT_MAX_POWER))
@@ -243,13 +251,18 @@ class PowerPredictorCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         raw_preds: np.ndarray = future_result["predictions"]
 
-        predictions: list[dict[str, Any]] = [
-            {
-                "timestamp": row["timestamp"].isoformat(),
-                "predicted": round(float(min(max_power, max(min_power, raw_preds[i]))), 3),
-            }
-            for i, (_, row) in enumerate(df_future.iterrows())
-        ]
+        predictions: list[dict[str, Any]] = []
+        for i, (_, row) in enumerate(df_future.iterrows()):
+            # Add the configured per-hour offset before clamping so min/max_power
+            # still bound the published value.
+            offset = hour_offsets.get(int(row["hour"]), 0.0)
+            value = min(max_power, max(min_power, raw_preds[i] + offset))
+            predictions.append(
+                {
+                    "timestamp": row["timestamp"].isoformat(),
+                    "predicted": round(float(value), 3),
+                }
+            )
 
         _LOGGER.info(
             "Pipeline complete — %d predictions from %s to %s  (trained on %d samples)",

--- a/custom_components/ha_power_predictor/data_processing.py
+++ b/custom_components/ha_power_predictor/data_processing.py
@@ -204,3 +204,39 @@ def get_default_features() -> list[str]:
     the configured n_power_lags and n_temp_lags values.
     """
     return ["year", "month", "day_of_week", "hour", "temperature"]
+
+
+def normalize_hour_offsets(raw: Any) -> dict[int, float]:
+    """
+    Normalize the configured hourly offsets into a {hour: offset} mapping.
+
+    Accepts the config ObjectSelector output — a list of {"hour": int,
+    "offset": float} rows — or a plain {hour: offset} mapping. Hours are coerced
+    to ints kept in 0–23 and offsets to floats; the last value wins when an hour
+    repeats, and malformed or out-of-range entries are silently dropped. Returns
+    an empty dict for empty/None input.
+    """
+    if not raw:
+        return {}
+
+    if isinstance(raw, dict):
+        items = list(raw.items())
+    elif isinstance(raw, (list, tuple)):
+        items = [
+            (entry.get("hour"), entry.get("offset"))
+            for entry in raw
+            if isinstance(entry, dict)
+        ]
+    else:
+        return {}
+
+    offsets: dict[int, float] = {}
+    for hour_raw, offset_raw in items:
+        try:
+            hour = int(hour_raw)
+            offset = float(offset_raw)
+        except (TypeError, ValueError):
+            continue
+        if 0 <= hour <= 23:
+            offsets[hour] = offset  # last value wins on duplicate hours
+    return offsets

--- a/custom_components/ha_power_predictor/strings.json
+++ b/custom_components/ha_power_predictor/strings.json
@@ -33,7 +33,8 @@
           "peak_end": "Peak Period End Hour (0–23)",
           "peak_quantile": "Peak Period Quantile",
           "offpeak_quantile": "Off-Peak Quantile",
-          "max_forecast_hours": "Max Forecast Hours"
+          "max_forecast_hours": "Max Forecast Hours",
+          "hour_offsets": "Hourly Offsets (kW)"
         },
         "data_description": {
           "min_power": "Clamp predicted values to at least this value in kW (0 = no minimum beyond zero) Set around you min overnight usage.",
@@ -48,15 +49,20 @@
           "peak_end": "Hour of day when the peak period ends (inclusive).",
           "peak_quantile": "Quantile applied during peak hours.",
           "offpeak_quantile": "Quantile applied during off-peak hours.",
-          "max_forecast_hours": "Maximum hours to forecast into the future (48–168 hours / 2-7 days). Note: Forecasts beyond weather data availability will use historical average temperature."
+          "max_forecast_hours": "Maximum hours to forecast into the future (48–168 hours / 2-7 days). Note: Forecasts beyond weather data availability will use historical average temperature.",
+          "hour_offsets": "Optional fixed kW added to the forecast for specific hours of the day (e.g. EV charging or a pool pump). Add a row per hour you want to adjust; omitted hours get no offset. Hours use the same (UTC-based) convention as the peak period."
         }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to Home Assistant recorder."
+      "cannot_connect": "Failed to connect to Home Assistant recorder.",
+      "invalid_hour_offsets": "Each offset row needs an hour between 0 and 23 and a numeric kW value."
     }
   },
   "options": {
+    "error": {
+      "invalid_hour_offsets": "Each offset row needs an hour between 0 and 23 and a numeric kW value."
+    },
     "step": {
       "init": {
         "title": "Model Parameters",
@@ -74,7 +80,8 @@
           "peak_end": "Peak Period End Hour",
           "peak_quantile": "Peak Period Quantile",
           "offpeak_quantile": "Off-Peak Quantile",
-          "max_forecast_hours": "Max Forecast Hours"
+          "max_forecast_hours": "Max Forecast Hours",
+          "hour_offsets": "Hourly Offsets (kW)"
         }
       }
     }

--- a/custom_components/ha_power_predictor/strings.json
+++ b/custom_components/ha_power_predictor/strings.json
@@ -34,7 +34,7 @@
           "peak_quantile": "Peak Period Quantile",
           "offpeak_quantile": "Off-Peak Quantile",
           "max_forecast_hours": "Max Forecast Hours",
-          "hour_offsets": "Hourly Offsets (kW)"
+          "hour_offsets": "Hour-of-day offsets"
         },
         "data_description": {
           "min_power": "Clamp predicted values to at least this value in kW (0 = no minimum beyond zero) Set around you min overnight usage.",
@@ -50,7 +50,7 @@
           "peak_quantile": "Quantile applied during peak hours.",
           "offpeak_quantile": "Quantile applied during off-peak hours.",
           "max_forecast_hours": "Maximum hours to forecast into the future (48–168 hours / 2-7 days). Note: Forecasts beyond weather data availability will use historical average temperature.",
-          "hour_offsets": "Optional fixed kW added to the forecast for specific hours of the day (e.g. EV charging or a pool pump). Add a row per hour you want to adjust; omitted hours get no offset. Hours use the same (UTC-based) convention as the peak period."
+          "hour_offsets": "Add a fixed kW offset at a chosen hour of the day, in local time: set the hour (0-23) and the kW to add — e.g. hour 13 adds the offset at 1 pm every day (good for EV charging or a pool pump). Hours not listed are unchanged; offsets may be negative and are still bounded by Min/Max Predicted Power."
         }
       }
     },
@@ -81,7 +81,7 @@
           "peak_quantile": "Peak Period Quantile",
           "offpeak_quantile": "Off-Peak Quantile",
           "max_forecast_hours": "Max Forecast Hours",
-          "hour_offsets": "Hourly Offsets (kW)"
+          "hour_offsets": "Hour-of-day offsets"
         }
       }
     }

--- a/custom_components/ha_power_predictor/translations/en.json
+++ b/custom_components/ha_power_predictor/translations/en.json
@@ -32,7 +32,7 @@
           "peak_quantile": "Peak Period Quantile",
           "offpeak_quantile": "Off-Peak Quantile",
           "max_forecast_hours": "Max Forecast Hours",
-          "hour_offsets": "Hourly Offsets (kW)"
+          "hour_offsets": "Hour-of-day offsets"
         },
         "data_description": {
           "min_power": "Clamp predicted values to at least this value in kW (0 = no minimum beyond zero) Set around you min overnight usage.",
@@ -46,7 +46,7 @@
           "peak_quantile": "Quantile applied during peak hours.",
           "offpeak_quantile": "Quantile applied during off-peak hours.",
           "max_forecast_hours": "Maximum hours to forecast into the future (48–168 hours / 2-7 days). Note: Forecasts beyond weather data availability will use historical average temperature.",
-          "hour_offsets": "Optional fixed kW added to the forecast for specific hours of the day (e.g. EV charging or a pool pump). Add a row per hour you want to adjust; omitted hours get no offset. Hours use the same (UTC-based) convention as the peak period."
+          "hour_offsets": "Add a fixed kW offset at a chosen hour of the day, in local time: set the hour (0-23) and the kW to add — e.g. hour 13 adds the offset at 1 pm every day (good for EV charging or a pool pump). Hours not listed are unchanged; offsets may be negative and are still bounded by Min/Max Predicted Power."
         }
       }
     },
@@ -75,7 +75,7 @@
           "peak_quantile": "Peak Period Quantile",
           "offpeak_quantile": "Off-Peak Quantile",
           "max_forecast_hours": "Max Forecast Hours",
-          "hour_offsets": "Hourly Offsets (kW)"
+          "hour_offsets": "Hour-of-day offsets"
         }
       }
     }

--- a/custom_components/ha_power_predictor/translations/en.json
+++ b/custom_components/ha_power_predictor/translations/en.json
@@ -31,7 +31,8 @@
           "peak_end": "Peak Period End Hour (0–23)",
           "peak_quantile": "Peak Period Quantile",
           "offpeak_quantile": "Off-Peak Quantile",
-          "max_forecast_hours": "Max Forecast Hours"
+          "max_forecast_hours": "Max Forecast Hours",
+          "hour_offsets": "Hourly Offsets (kW)"
         },
         "data_description": {
           "min_power": "Clamp predicted values to at least this value in kW (0 = no minimum beyond zero) Set around you min overnight usage.",
@@ -44,15 +45,20 @@
           "peak_end": "Hour of day when the peak period ends (inclusive).",
           "peak_quantile": "Quantile applied during peak hours.",
           "offpeak_quantile": "Quantile applied during off-peak hours.",
-          "max_forecast_hours": "Maximum hours to forecast into the future (48–168 hours / 2-7 days). Note: Forecasts beyond weather data availability will use historical average temperature."
+          "max_forecast_hours": "Maximum hours to forecast into the future (48–168 hours / 2-7 days). Note: Forecasts beyond weather data availability will use historical average temperature.",
+          "hour_offsets": "Optional fixed kW added to the forecast for specific hours of the day (e.g. EV charging or a pool pump). Add a row per hour you want to adjust; omitted hours get no offset. Hours use the same (UTC-based) convention as the peak period."
         }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to Home Assistant recorder."
+      "cannot_connect": "Failed to connect to Home Assistant recorder.",
+      "invalid_hour_offsets": "Each offset row needs an hour between 0 and 23 and a numeric kW value."
     }
   },
   "options": {
+    "error": {
+      "invalid_hour_offsets": "Each offset row needs an hour between 0 and 23 and a numeric kW value."
+    },
     "step": {
       "init": {
         "title": "Model Parameters",
@@ -68,7 +74,8 @@
           "peak_end": "Peak Period End Hour",
           "peak_quantile": "Peak Period Quantile",
           "offpeak_quantile": "Off-Peak Quantile",
-          "max_forecast_hours": "Max Forecast Hours"
+          "max_forecast_hours": "Max Forecast Hours",
+          "hour_offsets": "Hourly Offsets (kW)"
         }
       }
     }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "HA Power Predictor",
-  "homeassistant": "2024.1.0"
+  "homeassistant": "2025.7.0"
 }

--- a/tests/pure/test_data_processing.py
+++ b/tests/pure/test_data_processing.py
@@ -85,3 +85,34 @@ def test_add_lagged_features_shifts_and_drops_leading_rows():
 
 def test_get_default_features_exact_order():
     assert dp.get_default_features() == ["year", "month", "day_of_week", "hour", "temperature"]
+
+
+def test_normalize_hour_offsets_list_of_rows():
+    raw = [{"hour": 18, "offset": 0.8}, {"hour": 3, "offset": -0.3}]
+    assert dp.normalize_hour_offsets(raw) == {18: 0.8, 3: -0.3}
+
+
+def test_normalize_hour_offsets_dict_form():
+    assert dp.normalize_hour_offsets({"18": 0.8, 3: -0.3}) == {18: 0.8, 3: -0.3}
+
+
+def test_normalize_hour_offsets_duplicate_hour_last_wins():
+    raw = [{"hour": 5, "offset": 1.0}, {"hour": 5, "offset": 2.5}]
+    assert dp.normalize_hour_offsets(raw) == {5: 2.5}
+
+
+def test_normalize_hour_offsets_drops_out_of_range_and_malformed():
+    raw = [
+        {"hour": 24, "offset": 1.0},   # hour out of range
+        {"hour": -1, "offset": 1.0},   # hour out of range
+        {"hour": 9, "offset": "x"},    # non-numeric offset
+        {"offset": 1.0},               # missing hour
+        {"hour": 10, "offset": 2.0},   # valid
+    ]
+    assert dp.normalize_hour_offsets(raw) == {10: 2.0}
+
+
+def test_normalize_hour_offsets_empty_and_none():
+    assert dp.normalize_hour_offsets([]) == {}
+    assert dp.normalize_hour_offsets(None) == {}
+    assert dp.normalize_hour_offsets({}) == {}


### PR DESCRIPTION
## Summary

Adds a **per-hour fixed offset** to the power forecast (a user request). You can add a fixed kW amount to specific hours of the day — e.g. +7 kW while an EV charges 1–4 am, or a small negative bias overnight — to account for known recurring loads the model doesn't learn.

## How it works

- **UI:** under *Configure* (and initial setup), an "add row" form of `{hour, offset}` pairs (`ObjectSelector` with `fields` + `multiple`). You only enter the hours you want to adjust; offsets can be negative.
- **Applied** per prediction **before** the existing Min/Max Predicted Power clamp, so the clamp still bounds the published value.
- The in-sample **fitted** series and `fitted_coverage` are deliberately **left on the raw model** — that metric measures calibration, not a manual bias.
- Applies to all forecast sensors (24h / 48h / extended) automatically.

## Changes

- `const.py` — `CONF_HOUR_OFFSETS` / `DEFAULT_HOUR_OFFSETS`.
- `data_processing.py` — `normalize_hour_offsets()` (pure; list-of-rows or `{hour: offset}` → `{int: float}`, last-wins on dupes, drops out-of-range/malformed). Unit-tested.
- `config_flow.py` — the ObjectSelector field + `_hour_offsets_error()` validation in both the model step and options.
- `coordinator.py` — apply the offset in the predictions build.
- `strings.json` / `translations/en.json` — labels, description, `invalid_hour_offsets` error.
- `README.md` — `Hour Offsets` in the options table + a worked example.

## ⚠️ Minimum HA version bumped: 2024.1 → 2025.7

The `ObjectSelector` row form (`fields`/`multiple`) was introduced in **HA 2025.7**, so `hacs.json` and the README now require 2025.7+. (Alternative considered and declined: a plain YAML `ObjectSelector` that works on older HA but has a rawer UX.)

## Verification

- `ruff check .` clean; all JSON valid; `pytest tests/pure` covers `normalize_hour_offsets` (runs in CI).
- **Not covered by CI:** the config-flow form isn't exercised (no HA-harness job yet). Please confirm in a real HA ≥ 2025.7 that the row editor renders and that an offset shifts the forecast (bounded by max power) while `sensor.power_prediction_fitted_model` coverage is unchanged.

## Release note

Version/changelog are intentionally untouched here — this would ship in the next release (a 0.3.0-style minor), which is on hold per your call. The held `v0.2.2` / `zip_release` (#26) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
