### PR TITLE
feat(config): allow update interval down to 5 minutes

### DIFF
--- a/custom_components/ha_power_predictor/config_flow.py
+++ b/custom_components/ha_power_predictor/config_flow.py
@@ -99,7 +99,7 @@ def _model_schema(defaults: dict) -> vol.Schema:
             CONF_UPDATE_INTERVAL_MINUTES,
             default=_d(CONF_UPDATE_INTERVAL_MINUTES, DEFAULT_UPDATE_INTERVAL_MINUTES),
         ): selector.NumberSelector(
-            selector.NumberSelectorConfig(min=15, max=1440, step=15, mode="box")
+            selector.NumberSelectorConfig(min=5, max=1440, step=5, mode="box")
         ),
         vol.Required(
             CONF_N_POWER_LAGS,

--- a/custom_components/ha_power_predictor/strings.json
+++ b/custom_components/ha_power_predictor/strings.json
@@ -39,7 +39,7 @@
           "min_power": "Clamp predicted values to at least this value in kW (0 = no minimum beyond zero) Set around you min overnight usage.",
           "max_power": "Clamp predicted values to at most this value in kW. Set just above your typical peak usage.",
           "history_days": "How many days of historical data to train on (1–365).",
-          "update_interval_minutes": "How often to retrain and refresh predictions. Minimum 15 minutes.",
+          "update_interval_minutes": "How often to retrain and refresh predictions. Minimum 5 minutes.",
           "n_power_lags": "Number of previous hourly power readings to include as features (0 = none = past has no influence on future).",
           "n_temp_lags": "Number of previous hourly temperature readings to include as features (0 = none = past has no influence on future).",
           "use_dynamic_quantile": "When enabled, a higher quantile is used during peak hours and a lower quantile off-peak, giving more conservative estimates when consumption is typically highest.",

--- a/custom_components/ha_power_predictor/translations/en.json
+++ b/custom_components/ha_power_predictor/translations/en.json
@@ -37,7 +37,7 @@
           "min_power": "Clamp predicted values to at least this value in kW (0 = no minimum beyond zero) Set around you min overnight usage.",
           "max_power": "Clamp predicted values to at most this value in kW. Set just above your typical peak usage.",
           "history_days": "How many days of historical data to train on (1–365).",
-          "update_interval_minutes": "How often to retrain and refresh predictions. Minimum 15 minutes.",
+          "update_interval_minutes": "How often to retrain and refresh predictions. Minimum 5 minutes.",
           "n_power_lags": "Number of previous hourly power readings to include as features (0 = none = past has no influence on future).",
           "n_temp_lags": "Number of previous hourly temperature readings to include as features (0 = none = past has no influence on future).",
           "peak_start": "Hour of day when the peak period begins (inclusive).",


### PR DESCRIPTION
## Summary

Lets users refresh predictions as often as **every 5 minutes** (previously 15).

- `config_flow.py` — Update Interval `NumberSelector`: `min` 15 → **5**, and `step` 15 → **5** so 5/10/15/… are all selectable (with `step=15`, a `min=5` would only offer 5, 20, 35, …).
- `strings.json` + `translations/en.json` — help text "Minimum 15 minutes" → "Minimum 5 minutes".

**Side effect (bonus fix):** the existing default `DEFAULT_UPDATE_INTERVAL_MINUTES = 10` is now within range and a valid multiple of the step — previously the default (10) sat *below* the old minimum (15).

Branched off `main`; independent of the open offset (#27) and harness (#28) PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
