### PR TITLE
ci(release): exclude CLAUDE.md from the release zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Zip the integration
         run: |
           cd custom_components/ha_power_predictor
-          zip -r ha_power_predictor.zip .
+          # Exclude dev-only files (e.g. CLAUDE.md) from the shipped artifact.
+          zip -r ha_power_predictor.zip . -x "CLAUDE.md"
 
       - name: Attach zip to the release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Excludes `CLAUDE.md` from the release zip (`zip ... -x CLAUDE.md`). The v0.2.2 smoke test found it bundled into `ha_power_predictor.zip` — harmless (HA ignores it) but it's a dev-only file that shouldn't ship. Affects future releases only; v0.2.2 already shipped it harmlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)