### PR TITLE
fix(sensor): drop invalid power device_class on Fitted Model sensor

### DIFF
--- a/custom_components/ha_power_predictor/sensor.py
+++ b/custom_components/ha_power_predictor/sensor.py
@@ -241,7 +241,9 @@ class FittedModelSensor(CoordinatorEntity[PowerPredictorCoordinator], SensorEnti
     training_samples     Number of hourly records used for training.
     """
 
-    _attr_device_class = SensorDeviceClass.POWER
+    # The state is a coverage percentage, not power — no power device class.
+    # HA has no generic "percentage" device class, so leave device_class unset;
+    # "%" + MEASUREMENT is a valid combination on its own.
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "%"
     _attr_icon = "mdi:chart-bell-curve-cumulative"


### PR DESCRIPTION
## What

The **Fitted Model** sensor (`sensor.power_prediction_fitted_model`) emits an in-sample **coverage percentage** as its state, but was tagged `device_class = SensorDeviceClass.POWER` with unit `%`.

```python
_attr_device_class = SensorDeviceClass.POWER   # ← says "this is power"
_attr_native_unit_of_measurement = "%"         # ← but the value is a percentage
```

The state comes from `fitted_coverage` in `coordinator.py` (`np.mean(...) * 100`, a 0–100 %), so the `%` unit is correct — the `device_class` is the mistake. It's a copy-paste leftover from the two forecast sensors above it, which legitimately use `power` + `kW`.

## Why it matters

In Home Assistant, `SensorDeviceClass.POWER` only accepts power units (`W`, `kW`, …). Pairing it with `%`:
- logs unit-validation warnings on state updates,
- breaks long-term statistics for the entity (HA expects power-unit semantics/conversion),
- attaches power-flavored UI behavior to a value that isn't power.

## Fix

HA has no generic "percentage" device class, so the device class is removed entirely. `state_class = MEASUREMENT` + unit `%` is a valid standalone combination. The two forecast sensors are unchanged and still correctly use `power`/`kW`.

## Verification

- `python -m py_compile` passes; `SensorDeviceClass` import is still used by the forecast sensors.
- No tests or README assertions reference the device class (README already documents the unit as `%`).
- `ruff` lint and the `pytest tests/ha` harness run in CI (not installed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)